### PR TITLE
Fixing survey date

### DIFF
--- a/lib/section.dart
+++ b/lib/section.dart
@@ -65,7 +65,7 @@ class Section {
   /// Set the value of dateSurvey
   ///
   /// @param dateSurvey new value of dateSurvey
-  void setDateSurvey(DateTime dateSurvey) {
-    dateSurvey = dateSurvey;
+  void setDateSurvey(DateTime newDateSurvey) {
+    dateSurvey = newDateSurvey;
   }
 }


### PR DESCRIPTION
Survey date was not being properly setted: it was always the export date instead of the actual survey date.