### PR TITLE
Android build

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -88,6 +88,6 @@ jobs:
           cache: true
           architecture: x64
       - name: Build (Android APK)
-        run: flutter build apk
+        run: flutter build apk --release
       - name: Build (Android Appbundle)
-        run: flutter built appbundle
+        run: flutter built appbundle --release

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -88,6 +88,6 @@ jobs:
           cache: true
           architecture: x64
       - name: Build (Android APK)
-        run: flutter build apk --release
+        run: flutter build apk --debug
       - name: Build (Android Appbundle)
-        run: flutter built appbundle --release
+        run: flutter build appbundle --debug

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -69,3 +69,25 @@ jobs:
         run: flutter config --enable-windows-desktop
       - name: Build (Windows)
         run: flutter build windows
+
+  build-android:
+    name: Build for Android
+    runs-on: windows-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Setup Java 
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+      - name: Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+          architecture: x64
+      - name: Build (Android APK)
+        run: flutter build apk
+      - name: Build (Android Appbundle)
+        run: flutter built appbundle

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -87,6 +87,10 @@ jobs:
           channel: 'stable'
           cache: true
           architecture: x64
+      - name: Clean Flutter 
+        run: flutter clean
+      - name: Get new dependencies 
+        run: flutter pub get 
       - name: Build (Android APK)
         run: flutter build apk
       - name: Build (Android Appbundle)

--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -72,7 +72,7 @@ jobs:
 
   build-android:
     name: Build for Android
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -87,10 +87,6 @@ jobs:
           channel: 'stable'
           cache: true
           architecture: x64
-      - name: Clean Flutter 
-        run: flutter clean
-      - name: Get new dependencies 
-        run: flutter pub get 
       - name: Build (Android APK)
         run: flutter build apk
       - name: Build (Android Appbundle)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,6 +71,9 @@ android {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
+            signingConfig signingConfigs.release
+        }
+        debug {
             signingConfig null
         }
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -71,7 +71,7 @@ android {
         release {
             // TODO: Add your own signing config for the release build.
             // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig signingConfigs.release
+            signingConfig null
         }
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -58,6 +58,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
+dependency_overrides:  
+flutter_libserialport:
+  git:
+    url: https://github.com/speleobrad/flutter_libserialport.git
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 # The following section is specific to Flutter packages.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,7 +60,7 @@ dev_dependencies:
 
 dependency_overrides:  
   flutter_libserialport:
-    git: git@github.com:speleobrad/flutter_libserialport.git
+    git: https://github.com/speleobrad/flutter_libserialport.git
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -59,9 +59,8 @@ dev_dependencies:
     sdk: flutter
 
 dependency_overrides:  
-flutter_libserialport:
-  git:
-    url: https://github.com/speleobrad/flutter_libserialport.git
+  flutter_libserialport:
+    git: git@github.com:speleobrad/flutter_libserialport.git
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
After a bit of back and forth: 
- updated flutter_libserialport dependency to point to local (fixed) copy without TERMIOX
- added workflow for android
  - workflow uses debug buildType to check if everything compiles. This type is not signed 
  - default buildType (release) should still be intact. 
 
I don't have Android device to check if it actually works (nor can think of an actual usecase). 

Also, I didn't test if updated flutter_libserialport broke anything with Linux/Windows/MacOS builds, so consider testing that too.
If you'd like to merge, please squash. 