### PR TITLE
Fix linter and add multi-step workflow

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -13,9 +13,29 @@ on:
   workflow_dispatch:
 
 jobs:
+  linter:
+    name: Linter
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+          architecture: x64
+      - name: Ubuntu dependencies 
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y ninja-build libgtk-3-dev
+      - name: Linter check
+        run: flutter analyze
+
   build-linux:
     name: Build for Linux
     runs-on: ubuntu-latest
+    needs: linter
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -34,9 +54,10 @@ jobs:
       - name: Build (Linux)
         run: flutter build linux
         
-  build-mac:
+  build-macos:
     name: Build for MacOS
     runs-on: macos-latest
+    needs: linter
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -56,6 +77,7 @@ jobs:
   build-ios:
     name: Build for iOS
     runs-on: macos-latest
+    needs: [linter, build-macos]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -73,6 +95,7 @@ jobs:
   build-windows:
     name: Build for Windows
     runs-on: windows-latest
+    needs: linter
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4
@@ -90,6 +113,7 @@ jobs:
   build-android:
     name: Build for Android
     runs-on: ubuntu-latest
+    needs: [linter, build-linux]
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v4

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2247,6 +2247,10 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
+      if (!context.mounted) {
+        return;
+      }
+
       String? path = await FilesystemPicker.open(
           title: 'Save to folder',
           context: context,
@@ -2305,6 +2309,9 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
+      if (!context.mounted) {
+        return;
+      }
       String? path = await FilesystemPicker.open(
           title: 'Save to folder',
           context: context,
@@ -2355,6 +2362,9 @@ class _MyHomePageState extends State<MyHomePage> {
                 ExternalPath.DIRECTORY_DOCUMENTS));
       } else {
         rootPath = await getApplicationDocumentsDirectory();
+      }
+      if (!context.mounted) {
+        return;
       }
       String? path = await FilesystemPicker.open(
           title: 'Save to folder',
@@ -2407,7 +2417,9 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
-
+      if (!context.mounted) {
+        return;
+      }
       String? path = await FilesystemPicker.open(
           title: 'Save to folder',
           context: context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,11 +32,11 @@ dependencies:
     sdk: flutter
   characters: ^1.3.0
   cupertino_icons: null
-  archive: 3.4.10
+  archive: 3.4.9
   excel: ^4.0.0
   file_picker: ^6.1.1
   flutter_colorpicker: null
-  flutter_libserialport: 0.3.0
+  flutter_libserialport: null
   flutter_svg: null
   intl: null
   loading_animation_widget: null

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,11 +32,11 @@ dependencies:
     sdk: flutter
   characters: ^1.3.0
   cupertino_icons: null
-  archive: 3.4.9
+  archive: 3.4.10
   excel: ^4.0.0
   file_picker: ^6.1.1
   flutter_colorpicker: null
-  flutter_libserialport: null
+  flutter_libserialport: 0.3.0
   flutter_svg: null
   intl: null
   loading_animation_widget: null


### PR DESCRIPTION
Another drop of small changes: 
- fixed linter warnings about BuildContext. 
- reordered workflows to introduce build hierarchy - for example, IOS build will only be triggered after MacOS build is successful. This detects errors earlier but limits the parallelism to a certain extent. 
- Added quick linter job before anything gets build. It will fail on any issue (errors, warnings or info messages). Feel free to add --no-fatal-info or --no-fatal-warnings to lower the bar.
- Unrelated, I bumped the archive version to latest
