### PR TITLE
Proper libserial

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2247,7 +2247,7 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
-      if (!context.mounted) {
+      if (!mounted) {
         return;
       }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2309,7 +2309,7 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
-      if (!context.mounted) {
+      if (!mounted) {
         return;
       }
       String? path = await FilesystemPicker.open(
@@ -2363,7 +2363,7 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
-      if (!context.mounted) {
+      if (!mounted) {
         return;
       }
       String? path = await FilesystemPicker.open(
@@ -2417,7 +2417,7 @@ class _MyHomePageState extends State<MyHomePage> {
       } else {
         rootPath = await getApplicationDocumentsDirectory();
       }
-      if (!context.mounted) {
+      if (!mounted) {
         return;
       }
       String? path = await FilesystemPicker.open(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   excel: ^4.0.0
   file_picker: ^6.1.1
   flutter_colorpicker: null
-  flutter_libserialport: null
+  flutter_libserialport: ^0.4.0
   flutter_svg: null
   intl: null
   loading_animation_widget: null
@@ -62,9 +62,9 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-dependency_overrides:  
-  flutter_libserialport:
-    git: https://github.com/speleobrad/flutter_libserialport.git
+# dependency_overrides:  
+#  flutter_libserialport:
+#    git: https://github.com/speleobrad/flutter_libserialport.git
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec

--- a/windows/flutter/CMakeLists.txt
+++ b/windows/flutter/CMakeLists.txt
@@ -10,6 +10,11 @@ include(${EPHEMERAL_DIR}/generated_config.cmake)
 # https://github.com/flutter/flutter/issues/57146.
 set(WRAPPER_ROOT "${EPHEMERAL_DIR}/cpp_client_wrapper")
 
+# Set fallback configurations for older versions of the flutter tool.
+if (NOT DEFINED FLUTTER_TARGET_PLATFORM)
+  set(FLUTTER_TARGET_PLATFORM "windows-x64")
+endif()
+
 # === Flutter Library ===
 set(FLUTTER_LIBRARY "${EPHEMERAL_DIR}/flutter_windows.dll")
 
@@ -92,7 +97,7 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
     ${FLUTTER_TOOL_ENVIRONMENT}
     "${FLUTTER_ROOT}/packages/flutter_tools/bin/tool_backend.bat"
-      windows-x64 $<CONFIG>
+      ${FLUTTER_TARGET_PLATFORM} $<CONFIG>
   VERBATIM
 )
 add_custom_target(flutter_assemble DEPENDS


### PR DESCRIPTION
Official libflutterserial has been updated to resolve the issues that prompted us to have separate build of a lib. 
In addition, Flutter linter has introduced finer rules for build_context checks, which catches some stuff that I thought I addressed earlier. 