### PR TITLE
Add support for exporting walls data

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -14,6 +14,7 @@ import 'package:loading_animation_widget/loading_animation_widget.dart';
 import 'package:mnemolink/fileicon.dart';
 import 'package:mnemolink/survexporter.dart';
 import 'package:mnemolink/thexporter.dart';
+import 'package:mnemolink/wallsexporter.dart';
 import 'package:network_info_plus/network_info_plus.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:external_path/external_path.dart';
@@ -1273,6 +1274,23 @@ class _MyHomePageState extends State<MyHomePage> {
                                           : onExportTH,
                                       extension: 'TH',
                                       tooltip: "Export as Therion",
+                                      size: 24,
+                                      color: (serialBusy ||
+                                              sections.sections.isEmpty)
+                                          ? Colors.black26
+                                          : Colors.black54,
+                                      extensionColor: (serialBusy ||
+                                              sections.sections.isEmpty)
+                                          ? Colors.black26
+                                          : Colors.black87,
+                                    ),
+                                    FileIcon(
+                                      onPressed: (serialBusy ||
+                                              sections.sections.isEmpty)
+                                          ? null
+                                          : onExportWalls,
+                                      extension: 'SRV',
+                                      tooltip: "Export as Walls Data",
                                       size: 24,
                                       color: (serialBusy ||
                                               sections.sections.isEmpty)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2369,6 +2369,57 @@ class _MyHomePageState extends State<MyHomePage> {
     await exporter.export(sections, result, unitType);
   }
 
+  Future<void> onExportWalls() async {
+    String result;
+    if (Platform.isAndroid || Platform.isIOS) {
+      Directory? rootPath;
+      if (Platform.isAndroid) {
+        //Using document directory as default on Android
+        rootPath = Directory(
+            await ExternalPath.getExternalStoragePublicDirectory(
+                ExternalPath.DIRECTORY_DOCUMENTS));
+      } else {
+        rootPath = await getApplicationDocumentsDirectory();
+      }
+      if (!mounted) {
+        return;
+      }
+      String? path = await FilesystemPicker.open(
+          title: 'Save to folder',
+          context: context,
+          rootDirectory: rootPath,
+          fsType: FilesystemType.folder,
+          pickText: 'Save Walls file to this folder',
+          rootName: "Documents");
+
+      if (path == null) return;
+      final stamp = DateTime.timestamp().toLocal();
+      var stampString = sprintf("%02d%02d", [
+        stamp.day,
+        stamp.hour,
+      ]);
+      // Walls files are limited to 8 characters before the suffix
+      result = "$path/NEMO$stampString.SRV";
+    } else {
+      // Lets the enter file name, only files with the corresponding extensions are displayed
+      var resultFilePicker = await FilePicker.platform.saveFile(
+          dialogTitle: "Save as Walls Data",
+          type: FileType.custom,
+          allowedExtensions: ["SRV", "srv"]);
+      // The result will be null, if the user aborted the dialog
+      if (resultFilePicker == null) {
+        return;
+      } else {
+        result = resultFilePicker;
+      }
+    }
+
+    if (!result.toLowerCase().endsWith('.SRV') || !result.toLowerCase().endsWith('.srv')) result += ".SRV";
+
+    final exporter = WallsExporter();
+    await exporter.export(sections, result, unitType);
+  }
+
   Future<void> onExportTH() async {
     String result;
     if (Platform.isAndroid || Platform.isIOS) {

--- a/lib/shotexport.dart
+++ b/lib/shotexport.dart
@@ -163,6 +163,13 @@ mixin ShotExport {
     return svxDate;
   }
 
+  String dateInWallsFormat(DateTime date) {
+    final String wallsDate =
+        "${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}";
+
+    return svxDate;
+  }
+
   Future<String> getAppVersion() async {
     PackageInfo packageInfo = await PackageInfo.fromPlatform();
 

--- a/lib/shotexport.dart
+++ b/lib/shotexport.dart
@@ -167,7 +167,7 @@ mixin ShotExport {
     final String wallsDate =
         "${date.year.toString().padLeft(4, '0')}-${date.month.toString().padLeft(2, '0')}-${date.day.toString().padLeft(2, '0')}";
 
-    return svxDate;
+    return wallsDate;
   }
 
   Future<String> getAppVersion() async {

--- a/lib/wallsexporter.dart
+++ b/lib/wallsexporter.dart
@@ -1,0 +1,75 @@
+import 'package:mnemolink/section.dart';
+import 'package:mnemolink/shot.dart';
+import 'package:mnemolink/shotexport.dart';
+
+class WallsExporter with ShotExport {
+  @override
+  String get extension => '.SRV';
+
+  Future<String> headerComments() async {
+    final String version = await getAppVersion();
+
+    String header = '''
+; walls export file initially created:
+; * with MNemolink version $version
+; * at ${DateTime.now().toIso8601String()}
+
+; Cave notes:
+; CAVE NAME
+; PASSAGE LOCATION AND DESCRIPTION
+; PARTICIPANTS
+; OTHER NOTEABLE ITEMS
+
+''';
+
+    return header;
+  }
+
+  @override
+  Future<String> getContents(Section section, ExportShots exportShots,
+      String surveyName, UnitType unitType) async {
+    StringBuffer contents = StringBuffer(await headerComments());
+
+    contents.write(newLine('#DATE ${dateInWallsFormat(section.dateSurvey)}'));
+    contents.write(newLine('#PREFIX CHANGE_ME'));
+    contents.write('\n');
+
+    // Unit handling
+    if (unitType == UnitType.metric) {
+      contents.write(newLine('#UNITS meters ORDER=DA tape=SS'));
+    } else {
+      contents.write(newLine('#UNITS feet ORDER=DA tape=SS'));
+    }
+    contents.write('\n');
+
+    // Exporting first and last stations
+    final int lastStation = exportShots.shots.length + 1;
+    final String export = "1 ${lastStation.toString()}";
+    contents.write('\n');
+
+   // Main topo data
+    contents.write(newLine('; from\tto\tdist\taz\tdepth1\tdepth2'));
+    contents.write('\n');
+
+    bool firstLine = true;
+    for (ExportShot exportShot in exportShots.shots) {
+      if (exportShot.azimuthComments.isNotEmpty) {
+        if (!firstLine) {
+          contents.write('\n');
+        }
+
+        for (var comment in exportShot.azimuthComments) {
+          contents.write(newLine('; $comment'));
+        }
+      }
+
+      // Formatting the measurement line
+      contents.write(newLine(
+          '${exportShot.from}\t${exportShot.to}\t${exportShot.length.toStringAsFixed(2)}\t${exportShot.azimuthMean.toStringAsFixed(1)}\t${exportShot.depthIn.toStringAsFixed(2)}\t${exportShot.depthOut.toStringAsFixed(2)}'));
+      firstLine = false;
+    }
+    contents.write('\n');
+
+    return contents.toString();
+  }
+}


### PR DESCRIPTION
Add support for exporting files in walls format.  This relied heavily on Rodrigo's PR for survex support.  

Reference PR: #6 

I don't have a way to run this locally yet, so I have not run the code myself.  I'll see if I can get some support in testing this before it gets merged.