### PR TITLE
Fix broken segments/shots

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -900,7 +900,6 @@ class _MyHomePageState extends State<MyHomePage> {
           if (checkByteA != shotStartValueA ||
               checkByteB != shotStartValueB ||
               checkByteC != shotStartValueC) { 
-            debugPrint("Bad a beginning of a shot, inserting EOC and closing");
             shot = Shot.zero();
             shot.setTypeShot(TypeShot.eoc); 
             section.getShots().add(shot);
@@ -970,7 +969,6 @@ class _MyHomePageState extends State<MyHomePage> {
               checkByteB != shotEndValueB ||
               checkByteC != shotEndValueC) {
                 // this is where it gets weird - shot 
-                debugPrint ("Bad an end of a shot, inserting EOC and closing");
                 shot = Shot.zero();
                 shot.setTypeShot(TypeShot.eoc); 
                 section.getShots().add(shot);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -590,6 +590,35 @@ class _MyHomePageState extends State<MyHomePage> {
     );
   }
 
+    Future<void> brokenSegmentWarning() async {
+    return showDialog<void>(
+      context: context,
+      barrierDismissible: false, // user must tap button!
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('Broken segment'),
+          content: const SingleChildScrollView(
+            child: ListBody(
+              children: <Widget>[
+                Text('Broken segment detected and partially recovered'),
+                Text(
+                    'This usually happens when device hard resets or when segments is not finished and device is turned off'),
+              ],
+            ),
+          ),
+          actions: <Widget>[
+            TextButton(
+              child: const Text('Ok'),
+              onPressed: () {
+                Navigator.of(context).pop();
+              },
+            ),
+          ],
+        );
+      },
+    );
+  }
+
   Future<bool?> showFirmwareUpdateDialog() async {
     return showDialog<bool>(
       context: context,
@@ -806,7 +835,7 @@ class _MyHomePageState extends State<MyHomePage> {
     return byteData.getInt16(0);
   }
 
-  void analyzeTransferBuffer() {
+  void analyzeTransferBuffer() async {
     int currentMemory = transferBuffer.length;
     int cursor = 0;
 
@@ -904,6 +933,7 @@ class _MyHomePageState extends State<MyHomePage> {
             shot.setTypeShot(TypeShot.eoc); 
             section.getShots().add(shot);
             cursor -= 3; 
+            await brokenSegmentWarning();
             break; 
           }
         }
@@ -973,6 +1003,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 shot.setTypeShot(TypeShot.eoc); 
                 section.getShots().add(shot);
                 cursor -= 3; 
+                await brokenSegmentWarning();
                 break; 
           }
         }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -838,6 +838,7 @@ class _MyHomePageState extends State<MyHomePage> {
   void analyzeTransferBuffer() async {
     int currentMemory = transferBuffer.length;
     int cursor = 0;
+    bool brokenSegmentFlag = false;
 
     var fileVersionValueA = 68;
     var fileVersionValueB = 89;
@@ -933,8 +934,7 @@ class _MyHomePageState extends State<MyHomePage> {
             shot.setTypeShot(TypeShot.eoc); 
             section.getShots().add(shot);
             cursor -= 3; 
-            section.setBrokenFlag(true); 
-            await brokenSegmentWarning();
+            section.setBrokenFlag(true); brokenSegmentFlag = true;
             break; 
           }
         }
@@ -1004,8 +1004,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 shot.setTypeShot(TypeShot.eoc); 
                 section.getShots().add(shot);
                 cursor -= 3; 
-                section.setBrokenFlag(true); 
-                await brokenSegmentWarning();
+                section.setBrokenFlag(true); brokenSegmentFlag = true;
                 break; 
           }
         }
@@ -1017,6 +1016,9 @@ class _MyHomePageState extends State<MyHomePage> {
           sections.getSections().add(section);
         }
       });
+    }
+    if (brokenSegmentFlag) {
+      await brokenSegmentWarning(); 
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -976,7 +976,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 section.getShots().add(shot);
                 cursor -= 3; 
                 break; 
-          };
+          }
         }
       } while (shot.getTypeShot() != TypeShot.eoc);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -796,7 +796,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   int readByteFromEEProm(int address) {
-    return transferBuffer.elementAt(address);
+    return address < transferBuffer.length ? transferBuffer.elementAt(address) : 0;
   }
 
   int readIntFromEEProm(int address) {
@@ -899,7 +899,14 @@ class _MyHomePageState extends State<MyHomePage> {
           checkByteC = readByteFromEEProm(cursor++);
           if (checkByteA != shotStartValueA ||
               checkByteB != shotStartValueB ||
-              checkByteC != shotStartValueC) return;
+              checkByteC != shotStartValueC) { 
+            debugPrint("Bad a beginning of a shot, inserting EOC and closing");
+            shot = Shot.zero();
+            shot.setTypeShot(TypeShot.eoc); 
+            section.getShots().add(shot);
+            cursor -= 3; 
+            break; 
+          }
         }
         typeShot = readByteFromEEProm(cursor++);
 
@@ -954,15 +961,23 @@ class _MyHomePageState extends State<MyHomePage> {
         }
 
         shot.setMarkerIndex(readByteFromEEProm(cursor++));
+        section.getShots().add(shot);
         if (fileVersion >= 5) {
           checkByteA = readByteFromEEProm(cursor++);
           checkByteB = readByteFromEEProm(cursor++);
           checkByteC = readByteFromEEProm(cursor++);
           if (checkByteA != shotEndValueA ||
               checkByteB != shotEndValueB ||
-              checkByteC != shotEndValueC) return;
+              checkByteC != shotEndValueC) {
+                // this is where it gets weird - shot 
+                debugPrint ("Bad an end of a shot, inserting EOC and closing");
+                shot = Shot.zero();
+                shot.setTypeShot(TypeShot.eoc); 
+                section.getShots().add(shot);
+                cursor -= 3; 
+                break; 
+          };
         }
-        section.getShots().add(shot);
       } while (shot.getTypeShot() != TypeShot.eoc);
 
       setState(() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -933,6 +933,7 @@ class _MyHomePageState extends State<MyHomePage> {
             shot.setTypeShot(TypeShot.eoc); 
             section.getShots().add(shot);
             cursor -= 3; 
+            section.setBrokenFlag(true); 
             await brokenSegmentWarning();
             break; 
           }
@@ -1003,6 +1004,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 shot.setTypeShot(TypeShot.eoc); 
                 section.getShots().add(shot);
                 cursor -= 3; 
+                section.setBrokenFlag(true); 
                 await brokenSegmentWarning();
                 break; 
           }

--- a/lib/section.dart
+++ b/lib/section.dart
@@ -68,4 +68,14 @@ class Section {
   void setDateSurvey(DateTime newDateSurvey) {
     dateSurvey = newDateSurvey;
   }
+
+  bool brokenFlag = false; 
+
+  void setBrokenFlag  (bool flag) { 
+    brokenFlag = flag;
+  }
+
+  bool getBrokenFlag () { 
+    return brokenFlag;
+  }
 }

--- a/lib/sectioncard.dart
+++ b/lib/sectioncard.dart
@@ -34,7 +34,21 @@ class SectionCard extends StatelessWidget {
         title: Text(section.name),
         subtitle: Text(
             "${(section.direction == SurveyDirection.surveyIn) ? "IN" : "OUT"}-#${section.shots.length - 1}"),
-        trailing: Text(DateFormat('yyyy-MM-dd').format(section.dateSurvey)),
+        trailing: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget> [
+              if (section.getBrokenFlag()) 
+                const Tooltip(
+                  message: 'Recovered section', // Hover note
+                  child: Icon(
+                    Icons.fmd_bad, 
+                    color: Colors.orange,
+                  ),
+                ),
+              const SizedBox(width: 6), 
+              Text(DateFormat('yyyy-MM-dd').format(section.dateSurvey)),
+            ],            
+          ),
         leading: picture,
       ),
     );


### PR DESCRIPTION
Mnemo sometimes doesn't close the section properly so MNemoLink can't  display such sections and can't export them. 
Section is still there so this is an attempt to "recover" such sections by filling in the missing gaps ;) 

Under the hood - each section should end with a shot of type "eoc". If that's missing, this patch assumes it's the end of the section, processesses what it has up until that point and moves on. 

I tested with my own device (broken section is the last in order) and with hand-crafted .dmp where problematic section is in the middle or at the beginning of the file. 