### PR TITLE
Remove (unnecessary?) year checks.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -877,13 +877,7 @@ class _MyHomePageState extends State<MyHomePage> {
             checkByteC != fileVersionValueC) return;
       }
 
-      int year = 0;
-
-      while ((year < 16) || (year > (DateTime.now().year - 2000))) {
-        year = readByteFromEEProm(cursor);
-        cursor++;
-      }
-
+      int year = readByteFromEEProm(cursor++);
       year += 2000;
 
       int month = readByteFromEEProm(cursor);


### PR DESCRIPTION
This will address #96 by removing any checks and assuming integer present is the year after 2000 (or before, if it's negative).

I don't know what's the year export function in MNemo, to tell if we need additional checks (and don't have a device here to try it myself). For example, how would 1999 be represented? As 99 or as -1?  

If you can export relevant piece of (firmware) code, I can figure out what kind of checks to add to MNemoLink. 
Until then, this patch will work on all DMPs I have + the one you attached in the issue. 
 