### PR TITLE
Restore mobile builds and update flutter_libserialport to 0.6.0

### DIFF
--- a/.github/workflows/builds.yaml
+++ b/.github/workflows/builds.yaml
@@ -75,6 +75,33 @@ jobs:
         run: flutter build macos
 
 
+  build-ios:
+    name: Build for iOS
+    runs-on: macos-latest
+    needs: [linter, build-macos]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '16.4'
+      - name: Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+          architecture: x64
+      - name: MacOS dependencies
+        run: brew install automake libtool
+      - name: Show Xcode and iOS SDK info
+        run: |
+          xcodebuild -version
+          xcrun --show-sdk-path --sdk iphoneos
+          xcrun --show-sdk-version --sdk iphoneos
+      - name: Build (iOS)
+        run: flutter build ios --release --no-codesign
+        
   build-windows:
     name: Build for Windows
     runs-on: windows-latest
@@ -92,4 +119,27 @@ jobs:
         run: flutter config --enable-windows-desktop
       - name: Build (Windows)
         run: flutter build windows
+
+  build-android:
+    name: Build for Android
+    runs-on: ubuntu-latest
+    needs: [linter, build-linux]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+      - name: Setup Java 
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Install flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+          architecture: x64
+      - name: Build (Android APK)
+        run: flutter build apk --debug
+      - name: Build (Android Appbundle)
+        run: flutter build appbundle --debug
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,11 +42,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_colorpicker: null
-  flutter_libserialport: #^0.5.0
-    # remove this git part when 0.5.0 is published
-    git:
-      url: https://github.com/snabble/flutter_libserialport.git
-      ref: 0.5.0
+  flutter_libserialport: ^0.6.0
   flutter_svg: null
   intl: null
   loading_animation_widget: null


### PR DESCRIPTION
- Update flutter_libserialport from git version 0.5.0 to published ^0.6.0
- Restore Android build workflow with Java 17 and updated actions
- Restore iOS build workflow with Xcode version pinning and SDK info
- Both mobile builds now work with minimal configuration changes