### PR TITLE
Update documentation for DMP file format version 6

### DIFF
--- a/doc/MNemo DMP File Description.md
+++ b/doc/MNemo DMP File Description.md
@@ -228,14 +228,14 @@
     DataLength MSB;
 
     # Repeat for DataLength/6 triplet entries:
-    YAW LSB;    # (uint16_t) 1/100th of degree to magnetic north (0 = north)
-    YAW MSB;
+    YAW MSB;    # (uint16_t) 1/100th of degree to magnetic north (0 = north)
+    YAW LSB;    # Important: Big-endian
 
-    PITCH LSB;  # (int16_t) 1/100th of degree
-    PITCH MSB;
+    PITCH MSB;  # (int16_t) 1/100th of degree
+    PITCH LSB;  # Important: Big-endian
 
-    DISTANCE LSB; # (uint16_t) cm
-    DISTANCE MSB;
+    DISTANCE MSB; # (uint16_t) cm
+    DISTANCE LSB; # Important: Big-endian
 
 **[Section Termination]** _(35 Bytes)_
 

--- a/lib/services/file_service.dart
+++ b/lib/services/file_service.dart
@@ -136,9 +136,9 @@ class FileService {
       }
       
       final version = _parseElementOptimized(fields.first);
-      if (version == null || version < 2 || version > 5) {
+      if (version == null || version < 2 || version > 6) {
         return _ValidationResult.invalid(
-          "Invalid DMP file version: ${fields.first}. Supported versions: 2-5"
+          "Invalid DMP file version: ${fields.first}. Supported versions: 2-6"
         );
       }
       


### PR DESCRIPTION
- Add v6 format specification with optional Lidar data support
- Document big-endian encoding for Lidar point cloud data
- Include example binary data for v6 shot with Lidar records
- Add compatibility notes between v5 and v6 formats


- Update file_service.dart to support v6 format parsing
